### PR TITLE
29 January 2021, Redirections now handle syntax errors of all kinds o…

### DIFF
--- a/includes/statetable.h
+++ b/includes/statetable.h
@@ -6,7 +6,7 @@
 /*   By: limartin <limartin@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/10/15 19:53:22 by limartin      #+#    #+#                 */
-/*   Updated: 2020/12/10 22:02:12 by limartin      ########   odam.nl         */
+/*   Updated: 2021/01/29 11:42:18 by lindsay       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -409,7 +409,7 @@ static t_transition_obj const g_shellstate_table[] =
 	{sh_rd_entry_state, dredir_out, sh_error_state},
 	{sh_rd_entry_state, redir_out, sh_rd_entry_state},
 	{sh_rd_entry_state, redir_in, sh_error_state},
-	{sh_rd_entry_state, exit_state, sh_exit_state},
+	{sh_rd_entry_state, exit_state, sh_error_state},
 
 	{sh_rd_basic_state, padding, sh_rd_exit_state},
 	{sh_rd_basic_state, error, sh_error_state},
@@ -451,7 +451,7 @@ static t_transition_obj const g_shellstate_table[] =
 	{sh_rd_dq_state, dredir_out, sh_rd_dq_state},
 	{sh_rd_dq_state, redir_out, sh_rd_dq_state},
 	{sh_rd_dq_state, redir_in, sh_rd_dq_state},
-	{sh_rd_dq_state, exit_state, sh_exit_state},
+	{sh_rd_dq_state, exit_state, sh_error_state},
 
 	{sh_rd_sq_state, padding, sh_rd_sq_state},
 	{sh_rd_sq_state, error, sh_error_state},
@@ -465,7 +465,7 @@ static t_transition_obj const g_shellstate_table[] =
 	{sh_rd_sq_state, dredir_out, sh_rd_sq_state},
 	{sh_rd_sq_state, redir_out, sh_rd_sq_state},
 	{sh_rd_sq_state, redir_in, sh_rd_sq_state},
-	{sh_rd_sq_state, exit_state, sh_exit_state},
+	{sh_rd_sq_state, exit_state, sh_error_state},
 
 	{sh_rd_exit_quote_state, padding, sh_rd_exit_state},
 	{sh_rd_exit_quote_state, error, sh_error_state},

--- a/srcs/invalid.c
+++ b/srcs/invalid.c
@@ -6,7 +6,7 @@
 /*   By: jsaariko <jsaariko@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/10/27 10:09:20 by jsaariko      #+#    #+#                 */
-/*   Updated: 2021/01/28 18:58:12 by lindsay       ########   odam.nl         */
+/*   Updated: 2021/01/29 11:00:15 by lindsay       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,6 +48,8 @@ void	syntax_error(int fd, t_token **this)
 	e_write(fd, "syntax error near unexpected token `", 36);
 	if (*this != NULL)
 		e_write(fd, (*this)->token, ft_strlen((*this)->token));
+	if (*this == NULL)
+		e_write(fd, "newline", 7);
 	e_write(fd, "'\n", 2);
 }
 

--- a/srcs/parse/redir_basic_and_escape_states.c
+++ b/srcs/parse/redir_basic_and_escape_states.c
@@ -6,7 +6,7 @@
 /*   By: lindsay <lindsay@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/11/29 18:07:18 by lindsay       #+#    #+#                 */
-/*   Updated: 2020/12/04 16:30:22 by lindsay       ########   odam.nl         */
+/*   Updated: 2021/01/29 11:57:45 by lindsay       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,6 +38,11 @@ t_transition_code	sh_rd_bs_state(t_token **this, t_icomp **icur)
 		last = last->right;
 	if (recognise_token_state(*this) == backslash && *this)
 		*this = (*this)->next;
+	id = exit_state;
+	if ((*this) != NULL)
+		id = recognise_token_state(*this);
+	if (id == exit_state)
+		return (error);
 	if ((*this) != NULL)
 	{
 		ft_add_token_to_comp((*this), &(last->file));

--- a/srcs/parse/redir_quote_states.c
+++ b/srcs/parse/redir_quote_states.c
@@ -6,7 +6,7 @@
 /*   By: lindsay <lindsay@student.codam.nl>           +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2020/11/29 18:07:18 by lindsay       #+#    #+#                 */
-/*   Updated: 2020/12/04 16:29:31 by lindsay       ########   odam.nl         */
+/*   Updated: 2021/01/29 11:57:00 by lindsay       ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,6 +37,7 @@ t_transition_code	sh_rd_dq_state(t_token **this, t_icomp **icur)
 t_transition_code	sh_rd_exit_quote_state(t_token **this, t_icomp **icur)
 {
 	t_transition_code	id;
+	t_redir				*last;
 
 	(void)icur;
 	if ((recognise_token_state(*this) == dq || \
@@ -45,6 +46,11 @@ t_transition_code	sh_rd_exit_quote_state(t_token **this, t_icomp **icur)
 	id = exit_state;
 	if ((*this) != NULL)
 		id = recognise_token_state(*this);
+	last = (*icur)->rdhead;
+	while (last->right != NULL)
+		last = last->right;
+	if ((id == exit_state || id == separator) && ft_strlen(last->file) == 0)
+		id = error;
 	return (id);
 }
 
@@ -58,6 +64,11 @@ t_transition_code	sh_rd_dq_bs_state(t_token **this, t_icomp **icur)
 		last = last->right;
 	if (recognise_token_state(*this) == backslash && *this)
 		*this = (*this)->next;
+	id = exit_state;
+	if ((*this) != NULL)
+		id = recognise_token_state(*this);
+	if (id == exit_state)
+		return (error);
 	if ((*this) != NULL)
 	{
 		ft_add_token_to_comp((*this), &(last->file));


### PR DESCRIPTION
…f about-Muckery, mainly to do with empty strings as file names, empty quotes and unterminated quotes or backslashes etc.